### PR TITLE
Pass empty object to a function when no attributes specified

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -25,6 +25,8 @@ module.exports = vdo["default"] = vdo.createElement = vdo;
  * @returns {(Node|*)}
  */
 function vdo (type, attrs /*children...*/) {
+	attrs = attrs || {};
+
 	// Convert child arguments to an array.
 	var children = new Array(Math.max(arguments.length - 2, 0));
 	for (var i = children.length; i--;) children[i] = arguments[i + 2];

--- a/test/main.js
+++ b/test/main.js
@@ -52,6 +52,11 @@ describe("Node", function () {
 		assert.deepEqual(node.attrs, { a: undefined, b: null, c: false, d: true, e: 1, f: "hi" });
 		assert.equal(node.toString(), '<div d e="1" f="hi"></div>');
 	});
+	it("should set empty object when no attributes specified", function () {
+		var node = vdo("div", null);
+		assert.deepEqual(node.attrs, {});
+		assert.equal(node.toString(), '<div></div>');
+	});
 	it("should add children", function () {
 		var node = vdo("div", null, 1, 2, 3);
 		assert.equal(node.type, "div");


### PR DESCRIPTION
It allows optional props when components was called without any props, like this:

``` javascript
function Grid({ size }, children) {
    return (
        <div class={cx('photo-grid', size && `photo-grid_${size}`)}>
            {children}
        </div>
    );
}
```

This code works fine:

``` html
<Grid size="three">...</Grid>
```

But this didn’t because VDO passes `null` as a first argument.

``` html
<Grid>...</Grid>
```
